### PR TITLE
fix: replace deprecated char_at with get_char().unwrap()

### DIFF
--- a/src/fuzzy_match.mbt
+++ b/src/fuzzy_match.mbt
@@ -5,7 +5,7 @@
 pub fn[Pattern : StringLike, Text : StringLike] is_match(
   char_equal~ : (Char, Char) -> Bool = Char::op_equal,
   pattern~ : Pattern,
-  text~ : Text
+  text~ : Text,
 ) -> Bool {
   let mut pattern_idx = 0
   let mut text_idx = 0

--- a/src/fuzzy_match.mbti
+++ b/src/fuzzy_match.mbti
@@ -1,3 +1,4 @@
+// Generated using `moon info`, DON'T EDIT IT
 package "illusory0x0/fuzzy_match"
 
 import(
@@ -5,9 +6,11 @@ import(
 )
 
 // Values
-fn[Pattern : StringLike, Text : StringLike] is_match(char_equal~ : (Char, Char) -> Bool = .., pattern~ : Pattern, text~ : Text) -> Bool
+fn[Pattern : StringLike, Text : StringLike] is_match(char_equal? : (Char, Char) -> Bool, pattern~ : Pattern, text~ : Text) -> Bool
 
 fn score_upper_bound(query_length~ : Int) -> Int
+
+// Errors
 
 // Types and methods
 type Query

--- a/src/fuzzy_search.mbt
+++ b/src/fuzzy_search.mbt
@@ -1,7 +1,7 @@
 ///|
 fn[Query : StringLike, Item : StringLike] find_start_end_indices(
   query~ : Query,
-  item~ : Item
+  item~ : Item,
 ) -> StartEndIndices {
   let dst = the_one_and_only
   let mut item_idx = 0
@@ -37,7 +37,7 @@ fn[A, Query : StringLike, Item : StringLike] fold_matching_indices_single_query(
   query : Query,
   item~ : Item,
   init~ : A,
-  f~ : (A, Int) -> A
+  f~ : (A, Int) -> A,
 ) -> A {
   let { start_idx, end_idx, found } = find_start_end_indices(query~, item~)
   let mut acc = init
@@ -57,7 +57,7 @@ fn[A, Query : StringLike, Item : StringLike] fold_matching_indices_single_query(
 fn[Query : StringLike, Item : StringLike] score_single_query(
   query : Query,
   item~ : Item,
-  case_sensitive~ : Bool
+  case_sensitive~ : Bool,
 ) -> Int {
   let { found, start_idx, end_idx } = find_start_end_indices(query~, item~)
   if not(found) {

--- a/src/fuzzy_search_wtest.mbt
+++ b/src/fuzzy_search_wtest.mbt
@@ -38,9 +38,9 @@ test "search" {
   let items = ["___abc___", "aBc", "Abc_defgh", "abc", "foof"]
   inspect(
     Query::search(Query::new("abc"), items~),
-    content=
+    content=(
       $|[\"aBc\", \"abc\", \"Abc_defgh\", \"___abc___\"]
-    ,
+    ),
   )
 }
 
@@ -48,20 +48,20 @@ test "search" {
 test "split_by_matching_sections" {
   inspect(
     Query::split_by_matching_sections(Query::new("foo"), item="foo bar baz"),
-    content=
+    content=(
       $|Some([(true, \"foo\"), (false, \" bar baz\")])
-    ,
+    ),
   )
   inspect(
     Query::split_by_matching_sections(Query::new("abc"), item="____abc____"),
-    content=
+    content=(
       $|Some([(false, \"____\"), (true, \"abc\"), (false, \"____\")])
-    ,
+    ),
   )
   inspect(
     Query::split_by_matching_sections(Query::new("a ab"), item="a b"),
-    content=
+    content=(
       $|Some([(true, \"a\"), (false, \" \"), (true, \"b\")])
-    ,
+    ),
   )
 }

--- a/src/query.mbt
+++ b/src/query.mbt
@@ -29,7 +29,7 @@ pub fn Query::new(query : String) -> Query {
 ///|
 pub fn[Item : StringLike] split_by_matching_sections(
   self : Query,
-  item~ : Item
+  item~ : Item,
 ) -> Array[(Bool, @string.View)]? {
   match Query::matching_indices(self, item~) {
     None => None
@@ -69,7 +69,7 @@ pub fn[Item : StringLike] split_by_matching_sections(
 /// [Ocaml janestreet fuzzy_match](https://github.com/janestreet/fuzzy_match/blob/master/search/src/fuzzy_search.ml)
 pub fn[Item : StringLike + Compare] search(
   self : Query,
-  items~ : Array[Item]
+  items~ : Array[Item],
 ) -> Array[@string.View] {
   let items_by_score = items.filter_map(fn(item) {
     match Query::score(self, item~) {
@@ -87,7 +87,7 @@ pub fn[Item : StringLike + Compare] search(
 ///|
 pub fn[Item : StringLike] matching_indices(
   self : Query,
-  item~ : Item
+  item~ : Item,
 ) -> Array[Int]? {
   if self.is_empty() {
     Some([])
@@ -95,7 +95,7 @@ pub fn[Item : StringLike] matching_indices(
     let indices = self.queries.fold(init=Set::new(), fn(set, query) {
       fold_matching_indices_single_query(query, item~, init=set, f=fn(
         set,
-        query
+        query,
       ) {
         set.add(query)
         set

--- a/src/stringlike.mbt
+++ b/src/stringlike.mbt
@@ -14,7 +14,7 @@ pub impl StringLike for String with length(self) {
 
 ///|
 pub impl StringLike for String with op_get(self, index) {
-  self.char_at(index)
+  self.get_char(index).unwrap()
 }
 
 ///|
@@ -39,7 +39,7 @@ pub impl StringLike for @string.View with length(self) {
 
 ///|
 pub impl StringLike for @string.View with op_get(self, index) {
-  self.char_at(index)
+  self.get_char(index).unwrap()
 }
 
 ///|


### PR DESCRIPTION
> [!NOTE]
> This PR was made by an LLM agent.

Fixes compiler warnings about deprecated char_at method usage in StringLike trait implementations. Replaced self.char_at(index) with self.get_char(index).unwrap() for both String and @string.View implementations as suggested by the compiler warnings.

- Fixed 2 deprecation warnings in src/stringlike.mbt
- All compiler warnings are now resolved